### PR TITLE
7x7 gcode MBL workaround by @minout

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -4226,8 +4226,8 @@ if((eSoundMode==e_SOUND_MODE_LOUD)||(eSoundMode==e_SOUND_MODE_ONCE))
 			}
 			current_position[Z_AXIS] = 5;
 			plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 3000 / 60, active_extruder);
-			current_position[X_AXIS] = pgm_read_float(bed_ref_points);
-			current_position[Y_AXIS] = pgm_read_float(bed_ref_points + 1);
+			current_position[X_AXIS] = BED_X0;
+			current_position[Y_AXIS] = BED_Y0;
 			plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], 3000 / 60, active_extruder);
 			st_synchronize();
 			find_bed_induction_sensor_point_z(-1.f);
@@ -4345,6 +4345,13 @@ if((eSoundMode==e_SOUND_MODE_LOUD)||(eSoundMode==e_SOUND_MODE_ONCE))
 			break;
 		} 
 		
+    uint8_t nMeasPoints = MESH_MEAS_NUM_X_POINTS;
+ 		if (code_seen('N')) {
+ 			nMeasPoints = code_value_uint8();
+ 			if (nMeasPoints != 7) {
+ 				nMeasPoints = 3;
+ 			}
+ 		}
 		
 		bool temp_comp_start = true;
 #ifdef PINDA_THERMISTOR
@@ -4373,7 +4380,7 @@ if((eSoundMode==e_SOUND_MODE_LOUD)||(eSoundMode==e_SOUND_MODE_ONCE))
 		unsigned int custom_message_type_old = custom_message_type;
 		unsigned int custom_message_state_old = custom_message_state;
 		custom_message_type = CUSTOM_MSG_TYPE_MESHBL;
-		custom_message_state = (MESH_MEAS_NUM_X_POINTS * MESH_MEAS_NUM_Y_POINTS) + 10;
+		custom_message_state = (nMeasPoints * nMeasPoints) + 10;
 		lcd_update(1);
 
 		mbl.reset(); //reset mesh bed leveling
@@ -4387,8 +4394,8 @@ if((eSoundMode==e_SOUND_MODE_LOUD)||(eSoundMode==e_SOUND_MODE_ONCE))
 		current_position[Z_AXIS] = MESH_HOME_Z_SEARCH;
 		plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], homing_feedrate[Z_AXIS] / 60, active_extruder);
 		// The move to the first calibration point.
-		current_position[X_AXIS] = pgm_read_float(bed_ref_points);
-		current_position[Y_AXIS] = pgm_read_float(bed_ref_points + 1);
+		current_position[X_AXIS] = BED_X0;
+		current_position[Y_AXIS] = BED_Y0;
 
 		#ifdef SUPPORT_VERBOSITY
 		if (verbosity_level >= 1)
@@ -4402,14 +4409,14 @@ if((eSoundMode==e_SOUND_MODE_LOUD)||(eSoundMode==e_SOUND_MODE_ONCE))
 		// Wait until the move is finished.
 		st_synchronize();
 
-		int mesh_point = 0; //index number of calibration point
+		uint8_t mesh_point = 0; //index number of calibration point
 
-		int ix = 0;
-		int iy = 0;
+		uint8_t ix = 0;
+		uint8_t iy = 0;
 
 		int XY_AXIS_FEEDRATE = homing_feedrate[X_AXIS] / 20;
 		int Z_LIFT_FEEDRATE = homing_feedrate[Z_AXIS] / 40;
-		bool has_z = is_bed_z_jitter_data_valid(); //checks if we have data from Z calibration (offsets of the Z heiths of the 8 calibration points from the first point)
+		bool has_z = (nMeasPoints == 3) && is_bed_z_jitter_data_valid(); //checks if we have data from Z calibration (offsets of the Z heiths of the 8 calibration points from the first point)
 		#ifdef SUPPORT_VERBOSITY
 		if (verbosity_level >= 1) {
 			has_z ? SERIAL_PROTOCOLPGM("Z jitter data from Z cal. valid.\n") : SERIAL_PROTOCOLPGM("Z jitter data from Z cal. not valid.\n");
@@ -4417,13 +4424,13 @@ if((eSoundMode==e_SOUND_MODE_LOUD)||(eSoundMode==e_SOUND_MODE_ONCE))
 		#endif // SUPPORT_VERBOSITY
 		int l_feedmultiply = setup_for_endstop_move(false); //save feedrate and feedmultiply, sets feedmultiply to 100
 		const char *kill_message = NULL;
-		while (mesh_point != MESH_MEAS_NUM_X_POINTS * MESH_MEAS_NUM_Y_POINTS) {
+		while (mesh_point != nMeasPoints * nMeasPoints) {
 			// Get coords of a measuring point.
-			ix = mesh_point % MESH_MEAS_NUM_X_POINTS; // from 0 to MESH_NUM_X_POINTS - 1
-			iy = mesh_point / MESH_MEAS_NUM_X_POINTS;
-			if (iy & 1) ix = (MESH_MEAS_NUM_X_POINTS - 1) - ix; // Zig zag
+			ix = mesh_point % nMeasPoints; // from 0 to MESH_NUM_X_POINTS - 1
+			iy = mesh_point / nMeasPoints;
+			if (iy & 1) ix = (nMeasPoints - 1) - ix; // Zig zag
 			float z0 = 0.f;
-			if (has_z && mesh_point > 0) {
+			if (has_z && (mesh_point > 0)) {
 				uint16_t z_offset_u = eeprom_read_word((uint16_t*)(EEPROM_BED_CALIBRATION_Z_JITTER + 2 * (ix + iy * 3 - 1)));
 				z0 = mbl.z_values[0][0] + *reinterpret_cast<int16_t*>(&z_offset_u) * 0.01;
 				//#if 0
@@ -4446,8 +4453,8 @@ if((eSoundMode==e_SOUND_MODE_LOUD)||(eSoundMode==e_SOUND_MODE_ONCE))
 			st_synchronize();
 
 			// Move to XY position of the sensor point.
-			current_position[X_AXIS] = pgm_read_float(bed_ref_points + 2 * mesh_point);
-			current_position[Y_AXIS] = pgm_read_float(bed_ref_points + 2 * mesh_point + 1);
+			current_position[X_AXIS] = BED_X(ix, nMeasPoints);
+			current_position[Y_AXIS] = BED_Y(iy, nMeasPoints);
 
 
 
@@ -4518,7 +4525,7 @@ if((eSoundMode==e_SOUND_MODE_LOUD)||(eSoundMode==e_SOUND_MODE_ONCE))
 		#endif // SUPPORT_VERBOSITY
 		plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], Z_LIFT_FEEDRATE, active_extruder);
 		st_synchronize();
-		if (mesh_point != MESH_MEAS_NUM_X_POINTS * MESH_MEAS_NUM_Y_POINTS) {
+		if (mesh_point != nMeasPoints * nMeasPoints) {
                Sound_MakeSound(e_SOUND_TYPE_StandardAlert);
                bool bState;
                do   {                             // repeat until Z-leveling o.k.
@@ -4595,34 +4602,40 @@ if((eSoundMode==e_SOUND_MODE_LOUD)||(eSoundMode==e_SOUND_MODE_ONCE))
 			else {
 				switch (i) {
 				case 0:
-					for (uint8_t row = 0; row < 3; ++row) {
-						mbl.z_values[row][1] += 0.5f * offset;
-						mbl.z_values[row][0] += offset;
+					for (uint8_t row = 0; row < nMeasPoints; ++row) {
+            for (uint8_t col = 0; col < nMeasPoints - 1; ++col) {
+              mbl.z_values[row][col] += offset * (nMeasPoints - 1 - col) / (nMeasPoints - 1);
+ 						}
 					}
 					break;
 				case 1:
-					for (uint8_t row = 0; row < 3; ++row) {
-						mbl.z_values[row][1] += 0.5f * offset;
-						mbl.z_values[row][2] += offset;
+					for (uint8_t row = 0; row < nMeasPoints; ++row) {
+            for (uint8_t col = 1; col < nMeasPoints; ++col) {
+              mbl.z_values[row][col] += offset * col / (nMeasPoints - 1);
+            }
 					}
 					break;
 				case 2:
-					for (uint8_t col = 0; col < 3; ++col) {
-						mbl.z_values[1][col] += 0.5f * offset;
-						mbl.z_values[0][col] += offset;
+					for (uint8_t col = 0; col < nMeasPoints; ++col) {
+						for (uint8_t row = 0; row < nMeasPoints; ++row) {
+						 mbl.z_values[row][col] += offset * (nMeasPoints - 1 - row) / (nMeasPoints - 1);
+            }
 					}
 					break;
 				case 3:
-					for (uint8_t col = 0; col < 3; ++col) {
-						mbl.z_values[1][col] += 0.5f * offset;
-						mbl.z_values[2][col] += offset;
+					for (uint8_t col = 0; col < nMeasPoints; ++col) {
+						for (uint8_t row = 1; row < nMeasPoints; ++row) {
+						  mbl.z_values[row][col] += offset * row / (nMeasPoints - 1);
+            }
 					}
 					break;
 				}
 			}
 		}
 //		SERIAL_ECHOLNPGM("Bed leveling correction finished");
-		mbl.upsample_3x3(); //bilinear interpolation from 3x3 to 7x7 points while using the same array z_values[iy][ix] for storing (just coppying measured data to new destination and interpolating between them)
+    if (nMeasPoints == 3) {
+		  mbl.upsample_3x3(); //bilinear interpolation from 3x3 to 7x7 points while using the same array z_values[iy][ix] for storing (just coppying measured data to new destination and interpolating between them)
+    }
 //		SERIAL_ECHOLNPGM("Upsample finished");
 		mbl.active = 1; //activate mesh bed leveling
 //		SERIAL_ECHOLNPGM("Mesh bed leveling activated");

--- a/Firmware/mesh_bed_calibration.h
+++ b/Firmware/mesh_bed_calibration.h
@@ -1,6 +1,17 @@
 #ifndef MESH_BED_CALIBRATION_H
 #define MESH_BED_CALIBRATION_H
 
+#define BED_ZERO_REF_X (- 22.f + X_PROBE_OFFSET_FROM_EXTRUDER) // -22 + 23 = 1
+#define BED_ZERO_REF_Y (- 0.6f + Y_PROBE_OFFSET_FROM_EXTRUDER + 4.f) // -0.6 + 5 + 4 = 8.4
+ 
+#define BED_X0 (13.f - BED_ZERO_REF_X)
+#define BED_Y0 (10.4f - BED_ZERO_REF_Y)
+#define BED_Xn (216.f - BED_ZERO_REF_X)
+#define BED_Yn (202.4f - BED_ZERO_REF_Y)
+#define BED_X(i, n) ((float)i * (BED_Xn - BED_X0) / (n - 1) + BED_X0)
+#define BED_Y(i, n) ((float)i * (BED_Yn - BED_Y0) / (n - 1) + BED_Y0)
+ 
+
 // Exact positions of the print head above the bed reference points, in the world coordinates.
 // The world coordinates match the machine coordinates only in case, when the machine
 // is built properly, the end stops are at the correct positions and the axes are perpendicular.

--- a/Firmware/mesh_bed_leveling.cpp
+++ b/Firmware/mesh_bed_leveling.cpp
@@ -21,77 +21,77 @@ static inline bool vec_undef(const float v[2])
     return vx[0] == 0x0FFFFFFFF || vx[1] == 0x0FFFFFFFF;
 }
 
-void mesh_bed_leveling::get_meas_xy(int ix, int iy, float &x, float &y, bool /*use_default*/)
-{
-#if 0
-    float cntr[2] = {
-        eeprom_read_float((float*)(EEPROM_BED_CALIBRATION_CENTER+0)),
-        eeprom_read_float((float*)(EEPROM_BED_CALIBRATION_CENTER+4))
-    };
-    float vec_x[2] = {
-        eeprom_read_float((float*)(EEPROM_BED_CALIBRATION_VEC_X +0)),
-        eeprom_read_float((float*)(EEPROM_BED_CALIBRATION_VEC_X +4))
-    };
-    float vec_y[2] = {
-        eeprom_read_float((float*)(EEPROM_BED_CALIBRATION_VEC_Y +0)),
-        eeprom_read_float((float*)(EEPROM_BED_CALIBRATION_VEC_Y +4))
-    };
+// void mesh_bed_leveling::get_meas_xy(int ix, int iy, float &x, float &y, bool /*use_default*/)
+// {
+// #if 0
+//     float cntr[2] = {
+//         eeprom_read_float((float*)(EEPROM_BED_CALIBRATION_CENTER+0)),
+//         eeprom_read_float((float*)(EEPROM_BED_CALIBRATION_CENTER+4))
+//     };
+//     float vec_x[2] = {
+//         eeprom_read_float((float*)(EEPROM_BED_CALIBRATION_VEC_X +0)),
+//         eeprom_read_float((float*)(EEPROM_BED_CALIBRATION_VEC_X +4))
+//     };
+//     float vec_y[2] = {
+//         eeprom_read_float((float*)(EEPROM_BED_CALIBRATION_VEC_Y +0)),
+//         eeprom_read_float((float*)(EEPROM_BED_CALIBRATION_VEC_Y +4))
+//     };
 
-    if (use_default || vec_undef(cntr) || vec_undef(vec_x) || vec_undef(vec_y)) {
-        // Default, uncorrected positions of the calibration points. Works well for correctly built printers.
-        x = float(MESH_MIN_X) + float(MEAS_NUM_X_DIST) * float(ix) - X_PROBE_OFFSET_FROM_EXTRUDER;
-        //FIXME
-        //x -= 5.f;
-        y = float(MESH_MIN_Y) + float(MEAS_NUM_Y_DIST) * float(iy) - Y_PROBE_OFFSET_FROM_EXTRUDER;
-    } else {
-#if 0
-        SERIAL_ECHO("Running bed leveling. Calibration data: ");
-        SERIAL_ECHO(cntr[0]);
-        SERIAL_ECHO(",");
-        SERIAL_ECHO(cntr[1]);
-        SERIAL_ECHO(", x: ");
-        SERIAL_ECHO(vec_x[0]);
-        SERIAL_ECHO(",");
-        SERIAL_ECHO(vec_x[1]);
-        SERIAL_ECHO(", y: ");
-        SERIAL_ECHO(vec_y[0]);
-        SERIAL_ECHO(",");
-        SERIAL_ECHO(vec_y[1]);
-        SERIAL_ECHOLN("");
-#endif
+//     if (use_default || vec_undef(cntr) || vec_undef(vec_x) || vec_undef(vec_y)) {
+//         // Default, uncorrected positions of the calibration points. Works well for correctly built printers.
+//         x = float(MESH_MIN_X) + float(MEAS_NUM_X_DIST) * float(ix) - X_PROBE_OFFSET_FROM_EXTRUDER;
+//         //FIXME
+//         //x -= 5.f;
+//         y = float(MESH_MIN_Y) + float(MEAS_NUM_Y_DIST) * float(iy) - Y_PROBE_OFFSET_FROM_EXTRUDER;
+//     } else {
+// #if 0
+//         SERIAL_ECHO("Running bed leveling. Calibration data: ");
+//         SERIAL_ECHO(cntr[0]);
+//         SERIAL_ECHO(",");
+//         SERIAL_ECHO(cntr[1]);
+//         SERIAL_ECHO(", x: ");
+//         SERIAL_ECHO(vec_x[0]);
+//         SERIAL_ECHO(",");
+//         SERIAL_ECHO(vec_x[1]);
+//         SERIAL_ECHO(", y: ");
+//         SERIAL_ECHO(vec_y[0]);
+//         SERIAL_ECHO(",");
+//         SERIAL_ECHO(vec_y[1]);
+//         SERIAL_ECHOLN("");
+// #endif
 
-        x = cntr[0];
-        y = cntr[1];
-        if (ix < 1) {
-            x -= vec_x[0];
-            y -= vec_x[1];
-        } else if (ix > 1) {
-            x += vec_x[0];
-            y += vec_x[1];
-        }
-        if (iy < 1) {
-            x -= vec_y[0];
-            y -= vec_y[1];
-        } else if (iy > 1) {
-            x += vec_y[0];
-            y += vec_y[1];
-        }
+//         x = cntr[0];
+//         y = cntr[1];
+//         if (ix < 1) {
+//             x -= vec_x[0];
+//             y -= vec_x[1];
+//         } else if (ix > 1) {
+//             x += vec_x[0];
+//             y += vec_x[1];
+//         }
+//         if (iy < 1) {
+//             x -= vec_y[0];
+//             y -= vec_y[1];
+//         } else if (iy > 1) {
+//             x += vec_y[0];
+//             y += vec_y[1];
+//         }
 
-#if 0
-        SERIAL_ECHO("Calibration point position: ");
-        SERIAL_ECHO(x);
-        SERIAL_ECHO(",");
-        SERIAL_ECHO(y);
-        SERIAL_ECHOLN("");
-#endif
-    }
-#else
-    // Default, uncorrected positions of the calibration points.
-    // This coordinate will be corrected by the planner.
-    x = pgm_read_float(bed_ref_points + 2 * (iy * 3 + ix));
-    y = pgm_read_float(bed_ref_points + 2 * (iy * 3 + ix) + 1);
-#endif
-}
+// #if 0
+//         SERIAL_ECHO("Calibration point position: ");
+//         SERIAL_ECHO(x);
+//         SERIAL_ECHO(",");
+//         SERIAL_ECHO(y);
+//         SERIAL_ECHOLN("");
+// #endif
+//     }
+// #else
+//     // Default, uncorrected positions of the calibration points.
+//     // This coordinate will be corrected by the planner.
+//     x = pgm_read_float(bed_ref_points + 2 * (iy * 3 + ix));
+//     y = pgm_read_float(bed_ref_points + 2 * (iy * 3 + ix) + 1);
+// #endif
+// }
 
 #if MESH_NUM_X_POINTS>=5 && MESH_NUM_Y_POINTS>=5 && (MESH_NUM_X_POINTS&1)==1 && (MESH_NUM_Y_POINTS&1)==1
 // Works for an odd number of MESH_NUM_X_POINTS and MESH_NUM_Y_POINTS

--- a/Firmware/mesh_bed_leveling.h
+++ b/Firmware/mesh_bed_leveling.h
@@ -2,8 +2,8 @@
 
 #ifdef MESH_BED_LEVELING
 
-#define MEAS_NUM_X_DIST (float(MESH_MAX_X - MESH_MIN_X)/float(MESH_MEAS_NUM_X_POINTS - 1))
-#define MEAS_NUM_Y_DIST (float(MESH_MAX_Y - MESH_MIN_Y)/float(MESH_MEAS_NUM_Y_POINTS - 1))
+//#define MEAS_NUM_X_DIST (float(MESH_MAX_X - MESH_MIN_X)/float(MESH_MEAS_NUM_X_POINTS - 1))
+//#define MEAS_NUM_Y_DIST (float(MESH_MAX_Y - MESH_MIN_Y)/float(MESH_MEAS_NUM_Y_POINTS - 1))
 
 #define MESH_X_DIST (float(MESH_MAX_X - MESH_MIN_X)/float(MESH_NUM_X_POINTS - 1))
 #define MESH_Y_DIST (float(MESH_MAX_Y - MESH_MIN_Y)/float(MESH_NUM_Y_POINTS - 1))
@@ -27,7 +27,7 @@ public:
     // Measurement point for the Z probe.
     // If use_default=true, then the default positions for a correctly built printer are used.
     // Otherwise a correction matrix is pulled from the EEPROM if available.
-    static void get_meas_xy(int ix, int iy, float &x, float &y, bool use_default);
+    //static void get_meas_xy(int ix, int iy, float &x, float &y, bool use_default);
     
     void set_z(int ix, int iy, float z) { z_values[iy][ix] = z; }
     


### PR DESCRIPTION
Thanks to @minout for the live-saving 7x7 gcode workaround to get 7x7 MBL

I JUST took the changes in your firmware fork that actually provide the change.

So there is no PINDA temperature filtering/smoothing and no shifting of the temperature levels of 35 to 60C.

I also did NOT overtake your changes in planner.cpp, which seem to me like you deactivated the influence of the MBL during printing?! Please care to comment:

 lround((z/*+mbl.get_z(x, y)*/)*cs.axis_steps_per_unit[Z_AXIS]