### PR TITLE
Integrated ANTALIFE's change for filament detection and a quick #defi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # This FW is for use with MMU2S, in combination with [MMU2S-TZB-FW](https://github.com/TheZeroBeast/MM-control-01/tree/MMU2S-TZB)
+
+- Added antalife's MMU reliability fix.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # This FW is for use with MMU2S, in combination with [MMU2S-TZB-FW](https://github.com/TheZeroBeast/MM-control-01/tree/MMU2S-TZB)
 
-- Added antalife's MMU reliability fix.
+- Added antalife's MMU reliability fix. https://www.antalife.com/2020/08/project-mmu2s-filament-diameter.html

--- a/src/mmu.cpp
+++ b/src/mmu.cpp
@@ -38,6 +38,8 @@ static uint8_t mmu_attempt_nr = 0;
 #define MMU_RST_PIN 76
 #endif //MMU_HWRESET
 
+#define ALLOWED_MISSED_STEPS 20
+
 namespace
 { // MMU2S States
   enum class S : uint_least8_t
@@ -1166,7 +1168,7 @@ static bool can_load()
         st_synchronize();
         if(isEXTLoaded) ++filament_detected_count;
     }
-    if (filament_detected_count > steps - 4) return true;
+    if (filament_detected_count > steps - ALLOWED_MISSED_STEPS) return true;
     else return false;
 }
 


### PR DESCRIPTION
Integrated ANTALIFE's change for filament detection and a quick #define to make the allowed missed steps changeable at build time rather than a hardcoded 4

Read more here:
https://www.antalife.com/2020/08/project-mmu2s-filament-diameter.html

I am not sure if this change is for everyone, but I did run this antalife firmware and it did help me get far better reliability.  However, I cannot stand the stock MMU firmware, and much prefer TZB.  So this pull request is to move antalife's discovery into TZB.  

Perhaps as a new build target if not for everyone?

Also I would love to build this myself, any quick pointers / urls on how to get started are much appreciated.

Thank you TZB!!


https://www.antalife.com/2020/08/project-mmu2s-filament-diameter.html